### PR TITLE
add dataset loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test_local: test_verbose
 
 private go-cmds := client server
 define go-cmd-build =
-cmd/$1/$1: cmd/$1/*.go $(wildcard */*.go */*/*.go)
+cmd/$1/$1: cmd/$1/*.go $(wildcard */*.go */*/*.go */*/*/*.go)
 	go build -o $$@ ./$$(<D)
 endef
 $(foreach c,$(go-cmds),$(eval $(call go-cmd-build,$c)))

--- a/cmd/client/config.go
+++ b/cmd/client/config.go
@@ -6,7 +6,7 @@ import (
 	kyber_encoding "go.dedis.ch/kyber/v3/util/encoding"
 	onet_network "go.dedis.ch/onet/v3/network"
 
-	drynx_lib "github.com/ldsec/drynx/lib"
+	"github.com/ldsec/drynx/lib"
 
 	"github.com/pelletier/go-toml"
 )
@@ -18,6 +18,7 @@ type configNetwork struct {
 type configSurvey struct {
 	Name      *string
 	Operation *string
+	Sources   *[]libdrynx.ColumnID
 }
 type config struct {
 	Network *configNetwork
@@ -41,7 +42,7 @@ type configStr struct {
 }
 
 func serverIdentityToUnsafe(id onet_network.ServerIdentity) (serverIdentityStr, error) {
-	point, err := kyber_encoding.PointToStringHex(drynx_lib.Suite, id.Public)
+	point, err := kyber_encoding.PointToStringHex(libdrynx.Suite, id.Public)
 	if err != nil {
 		return serverIdentityStr{}, err
 	}
@@ -81,7 +82,7 @@ func (conf configNetworkStr) toSafe() (configNetwork, error) {
 
 	nodes := make([]onet_network.ServerIdentity, len(conf.Nodes))
 	for i, n := range conf.Nodes {
-		point, err := kyber_encoding.StringHexToPoint(drynx_lib.Suite, n.PublicKey)
+		point, err := kyber_encoding.StringHexToPoint(libdrynx.Suite, n.PublicKey)
 		if err != nil {
 			return configNetwork{}, err
 		}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -23,6 +23,7 @@ func main() {
 			$my_network_config
 	if you want to generate a survey config, use something like
 		%[1]s survey new my-survey |
+			%[1]s survey set-sources my-column |
 			%[1]s survey set-operation mean >
 			$my_survey_config
 	then, you can launch a given survey on a given network
@@ -55,6 +56,11 @@ func main() {
 			ArgsUsage: "name",
 			Usage:     "generate a survey config with the given name, start a survey config stream",
 			Action:    surveyNew,
+		}, {
+			Name:      "set-sources",
+			ArgsUsage: "column-name...",
+			Usage:     "on a survey config stream, set the sources columns names",
+			Action:    surveySetSources,
 		}, {
 			Name:      "set-operation",
 			ArgsUsage: "operation",

--- a/cmd/client/survey.go
+++ b/cmd/client/survey.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/urfave/cli"
 
-	drynx_lib "github.com/ldsec/drynx/lib"
-	drynx_services "github.com/ldsec/drynx/services"
+	"github.com/ldsec/drynx/lib"
+	"github.com/ldsec/drynx/services"
 	kyber "go.dedis.ch/kyber/v3"
 	onet "go.dedis.ch/onet/v3"
 	onet_network "go.dedis.ch/onet/v3/network"
@@ -39,6 +39,26 @@ func getRoster(conf configNetwork) (onet.Roster, error) {
 	}
 
 	return *rosterRaw, nil
+}
+
+func surveySetSources(c *cli.Context) error {
+	args := c.Args()
+	if len(args) == 0 {
+		return errors.New("usually, operation needs inputs")
+	}
+
+	conf, err := readConfigFrom(os.Stdin)
+	if err != nil {
+		return err
+	}
+
+	sources := make([]libdrynx.ColumnID, len(args))
+	for i, a := range args {
+		sources[i] = libdrynx.ColumnID(a)
+	}
+	conf.Survey.Sources = &sources
+
+	return conf.writeTo(os.Stdout)
 }
 
 func surveySetOperation(c *cli.Context) error {
@@ -79,7 +99,7 @@ func surveyRun(c *cli.Context) error {
 	if conf.Network.Client == nil {
 		return errors.New("no client defined")
 	}
-	client := drynx_services.NewDrynxClient(conf.Network.Client, os.Args[0])
+	client := services.NewDrynxClient(conf.Network.Client, os.Args[0])
 
 	if conf.Survey == nil {
 		return errors.New("need some survey config")
@@ -87,68 +107,67 @@ func surveyRun(c *cli.Context) error {
 	if conf.Survey.Name == nil {
 		return errors.New("need a survey name")
 	}
+	if conf.Survey.Sources == nil {
+		return errors.New("need some survey operation sources")
+	}
 	if conf.Survey.Operation == nil {
 		return errors.New("need a survey operation")
 	}
-	sq := client.GenerateSurveyQuery(
+	operation := libdrynx.ChooseOperation(
+		*conf.Survey.Operation, // operation
+		len(roster.List),       // min num of DP to query
+		len(roster.List),       // max num of DP to query
+		5,                      // dimension for linear regression
+		0)                      // "cutting factor", how much to remove of gen data[0:#/n]
+	if operation.NbrInput != len(*conf.Survey.Sources) {
+		return errors.New("Operation can't take #Sources")
+	}
 
-		/// network
-
-		&roster, // CN roster
-		&roster, // VN roster
-		map[string]*[]onet_network.ServerIdentity{ // map CN to DPs
+	_, aggregations, err := client.SendSurveyQuery(libdrynx.SurveyQuery{
+		SurveyID:      *conf.Survey.Name,
+		RosterServers: roster,
+		ServerToDP: map[string]*[]onet_network.ServerIdentity{ // map CN to DPs
 			roster.List[0].String(): &[]onet_network.ServerIdentity{*roster.List[1], *roster.List[2]}},
-		map[string]kyber.Point{ // map CN|DP|VN to pub key
+		IDtoPublic: map[string]kyber.Point{ // map CN|DP|VN to pub key
 			roster.List[0].String(): roster.List[0].Public,
 			roster.List[1].String(): roster.List[1].Public,
 			roster.List[2].String(): roster.List[2].Public},
 
-		/// gen
+		Threshold:                  0,
+		AggregationProofThreshold:  0,
+		ObfuscationProofThreshold:  0,
+		RangeProofThreshold:        0,
+		KeySwitchingProofThreshold: 0,
 
-		*conf.Survey.Name, // survey id
-		drynx_lib.ChooseOperation(
-			*conf.Survey.Operation, // operation
-			len(roster.List),       // min num of DP to query
-			len(roster.List),       // max num of DP to query
-			5,                      // dimension for linear regression
-			0),                     // "cutting factor", how much to remove of gen data[0:#/n]
-
-		[]*[]int64{}, // range for each output of operation
-		nil,          // signature of range validity
-		int(0),       // 0 == no proof, 1 == proof, 2 == optimized proof
-
-		false, // obfuscation
-		[]float64{
-			1.0,  // threshold general
-			1.0,  // threshold aggregation
-			1.0,  // threshold range
-			0.0,  // obfuscation
-			1.0}, // threshold key switch
-		drynx_lib.QueryDiffP{ // differential privacy
-			LapMean: 0.0, LapScale: 0.0, NoiseListSize: 0, Quanta: 0.0, Scale: 0},
-		drynx_lib.QueryDPDataGen{ // how to group by
-			GroupByValues: []int64{3, 2, 1}, GenerateRows: 10, GenerateDataMin: int64(0), GenerateDataMax: int64(256)},
-		0, // cutting factor
-	)
-
-	_, aggregations, err := client.SendSurveyQuery(sq)
+		Query: libdrynx.Query{
+			Operation:   operation,
+			Ranges:      []*[]int64{}, // range for each output of operation
+			Proofs:      int(0),       // 0 == no proof, 1 == proof, 2 == optimized proof
+			Obfuscation: false,
+			DiffP: libdrynx.QueryDiffP{ // differential privacy
+				LapMean: 0.0, LapScale: 0.0, NoiseListSize: 0, Quanta: 0.0, Scale: 0},
+			DPDataGen: libdrynx.QueryDPDataGen{ // how to group by
+				GroupByValues: []int64{1, 1, 1}, GenerateRows: 10, GenerateDataMin: int64(0), GenerateDataMax: int64(256)},
+			IVSigs: libdrynx.QueryIVSigs{
+				InputValidationSigs:  make([]*[]libdrynx.PublishSignatureBytes, 0),
+				InputValidationSize1: 0,
+				InputValidationSize2: 0,
+			},
+			RosterVNs:     &roster,
+			CuttingFactor: 0,
+			Selector:      *conf.Survey.Sources,
+		},
+	})
 	if err != nil {
 		return err
 	}
 
-	result, ok := float64(0), false
-	for _, a := range *aggregations {
-		if len(a) != 1 {
-			return errors.New("line in aggregation larger than one, dunno how to print")
-		}
-		if ok && result != a[0] {
-			return errors.New("not same value found in aggregation, dunno how to print")
-		}
-		result = a[0]
-		ok = true
+	if len(*aggregations) != 1 {
+		return errors.New("single group expected")
 	}
-
-	fmt.Println(result)
+	for _, a := range (*aggregations)[0] {
+		fmt.Println(a)
+	}
 
 	return nil
 }

--- a/cmd/server/config.go
+++ b/cmd/server/config.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"io"
+
+	kyber_encoding "go.dedis.ch/kyber/v3/util/encoding"
+	kyber_key "go.dedis.ch/kyber/v3/util/key"
+	onet_network "go.dedis.ch/onet/v3/network"
+
+	drynx_lib "github.com/ldsec/drynx/lib"
+
+	"github.com/pelletier/go-toml"
+)
+
+type configDataProviderFileLoader struct {
+	Path string
+}
+type configDataProvider struct {
+	FileLoader *configDataProviderFileLoader
+	Random     *struct{}
+}
+type config struct {
+	Address onet_network.Address
+	URL     string
+	Key     kyber_key.Pair
+
+	DataProvider  *configDataProvider
+	ComputingNode *struct{}
+	VerifyingNode *struct{}
+}
+
+type keyPairStr struct {
+	Public  string
+	Private string
+}
+type configStr struct {
+	Address onet_network.Address
+	URL     string
+	Key     keyPairStr
+
+	DataProvider  *configDataProvider
+	ComputingNode *struct{}
+	VerifyingNode *struct{}
+}
+
+func keyPairToUnsafe(kp kyber_key.Pair) (keyPairStr, error) {
+	pub, err := kyber_encoding.PointToStringHex(drynx_lib.Suite, kp.Public)
+	if err != nil {
+		return keyPairStr{}, err
+	}
+
+	priv, err := kyber_encoding.ScalarToStringHex(drynx_lib.Suite, kp.Private)
+	if err != nil {
+		return keyPairStr{}, err
+	}
+
+	return keyPairStr{
+		Public:  pub,
+		Private: priv,
+	}, nil
+}
+
+func (kp keyPairStr) toSafe() (kyber_key.Pair, error) {
+	pub, err := kyber_encoding.StringHexToPoint(drynx_lib.Suite, kp.Public)
+	if err != nil {
+		return kyber_key.Pair{}, err
+	}
+
+	priv, err := kyber_encoding.StringHexToScalar(drynx_lib.Suite, kp.Private)
+	if err != nil {
+		return kyber_key.Pair{}, err
+	}
+
+	return kyber_key.Pair{
+		Public:  pub,
+		Private: priv,
+	}, nil
+}
+
+func readConfigFrom(r io.Reader) (config, error) {
+	var conf configStr
+	err := toml.NewDecoder(r).Decode(&conf)
+
+	key, err := conf.Key.toSafe()
+	if err != nil {
+		return config{}, err
+	}
+
+	return config{
+		conf.Address,
+		conf.URL,
+		key,
+
+		conf.DataProvider,
+		conf.ComputingNode,
+		conf.VerifyingNode,
+	}, nil
+}
+
+func (conf config) writeTo(w io.Writer) error {
+	key, err := keyPairToUnsafe(conf.Key)
+	if err != nil {
+		return err
+	}
+
+	conv := configStr{
+		conf.Address,
+		conf.URL,
+		key,
+
+		conf.DataProvider,
+		conf.ComputingNode,
+		conf.VerifyingNode,
+	}
+
+	return toml.NewEncoder(w).Encode(conv)
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -219,5 +219,6 @@ func main() {
 
 	if err := app.Run(os.Args); err != nil {
 		onet_log.Error(err)
+		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.12
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/alex-ant/gomath v0.0.0-20160516115720-89013a210a82
-	github.com/btcsuite/goleveldb v1.0.0
 	github.com/cdipaolo/goml v0.0.0-20190412180403-e1f51f713598
 	github.com/coreos/bbolt v1.3.3
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,10 +26,7 @@ github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufo
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
 github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVaaLLH7j4eDXPRvw78tMflu7Ie2bzYOH4Y8rRKBY=
-github.com/btcsuite/goleveldb v1.0.0 h1:Tvd0BfvqX9o823q1j2UZ/epQo09eJh6dTcRp79ilIN4=
-github.com/btcsuite/goleveldb v1.0.0/go.mod h1:QiK9vBlgftBg6rWQIj6wFzbPfRjiykIEhBH4obrXJ/I=
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
-github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/cdipaolo/goml v0.0.0-20190412180403-e1f51f713598 h1:j2XRGH5Y5uWtBYXGwmrjKeM/kfu/jh7ZcnrGvyN5Ttk=
@@ -126,7 +123,6 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
-github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/openconfig/gnmi v0.0.0-20190823184014-89b2bf29312c/go.mod h1:t+O9It+LKzfOAhKTT5O0ehDix+MTqbtT0T9t+7zzOvc=
@@ -223,7 +219,6 @@ golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2 h1:y102fOLFqhV41b+4GPiJoa0k/
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
-golang.org/x/net v0.0.0-20180719180050-a680a1efc54d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/lib/provider/index.go
+++ b/lib/provider/index.go
@@ -1,0 +1,10 @@
+package provider
+
+import "github.com/ldsec/drynx/lib"
+
+// Loader is the way to retrieve local data.
+type Loader interface {
+	// Provide returns the queried rows to encode.
+	// Returns a matrix of len Query.Operation.NbrInput
+	Provide(libdrynx.Query) ([][]float64, error)
+}

--- a/lib/provider/loaders/file.go
+++ b/lib/provider/loaders/file.go
@@ -1,0 +1,56 @@
+package loaders
+
+import (
+	"encoding/csv"
+	"errors"
+	"os"
+	"strconv"
+
+	"github.com/ldsec/drynx/lib"
+	"github.com/ldsec/drynx/lib/provider"
+)
+
+type fileLoader struct {
+	file os.File
+}
+
+// NewFileLoader creates a Loader backing the file found at the given path.
+func NewFileLoader(path string) (provider.Loader, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	return fileLoader{*file}, nil
+}
+
+func (f fileLoader) Provide(query libdrynx.Query) ([][]float64, error) {
+	_, err := f.file.Seek(0, os.SEEK_SET)
+	if err != nil {
+		return nil, err
+	}
+
+	reader := csv.NewReader(&f.file)
+	reader.Comma = '\t'
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+
+	if reader.FieldsPerRecord < query.Operation.NbrInput {
+		return nil, errors.New("not enough column for the operation")
+	}
+
+	ret := make([][]float64, query.Operation.NbrInput)
+	for i := range ret {
+		arr := make([]float64, len(records))
+		for j, r := range records {
+			arr[j], err = strconv.ParseFloat(r[i], 64)
+			if err != nil {
+				return nil, err
+			}
+		}
+		ret[i] = arr
+	}
+
+	return ret, nil
+}

--- a/lib/provider/loaders/random.go
+++ b/lib/provider/loaders/random.go
@@ -1,0 +1,30 @@
+package loaders
+
+import (
+	"math/rand"
+
+	"github.com/ldsec/drynx/lib"
+	"github.com/ldsec/drynx/lib/provider"
+)
+
+type random struct{}
+
+// NewRandom create a Loader of random values.
+func NewRandom() (provider.Loader, error) {
+	return random{}, nil
+}
+
+func (random) Provide(query libdrynx.Query) ([][]float64, error) {
+	ret := make([][]float64, query.Operation.NbrInput)
+
+	min, max := query.DPDataGen.GenerateDataMin, query.DPDataGen.GenerateDataMax
+
+	for i := range ret {
+		arr := make([]float64, query.DPDataGen.GenerateRows)
+		for j := range arr {
+			arr[j] = float64(min + rand.Int63n(max-min))
+		}
+		ret[i] = arr
+	}
+	return ret, nil
+}

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -159,6 +159,9 @@ type QueryIVSigs struct {
 	InputValidationSize2 int
 }
 
+// ColumnID is a reference to a "column" the Loader can extract
+type ColumnID string
+
 // Query is used to transport query information through servers, to DPs
 type Query struct {
 	// query statement
@@ -177,6 +180,9 @@ type Query struct {
 
 	//simulation
 	CuttingFactor int
+
+	// allow to select which column to compute operation on
+	Selector []ColumnID
 }
 
 // Operation defines the operation in the query

--- a/lib/structs.go
+++ b/lib/structs.go
@@ -107,12 +107,6 @@ type ResponseDPBytes struct {
 	Len  int
 }
 
-// WhereQueryAttributeClear is the name and value of a where attribute in the query
-type WhereQueryAttributeClear struct {
-	Name  string
-	Value string
-}
-
 // ShufflingMessage represents a message containing data to shuffle
 type ShufflingMessage struct {
 	Data []libunlynx.ProcessResponse
@@ -165,14 +159,6 @@ type QueryIVSigs struct {
 	InputValidationSize2 int
 }
 
-// QuerySQL contains SQL parameters of the query
-type QuerySQL struct {
-	Select    []string
-	Where     []WhereQueryAttributeClear
-	Predicate string
-	GroupBy   []string
-}
-
 // Query is used to transport query information through servers, to DPs
 type Query struct {
 	// query statement
@@ -188,9 +174,6 @@ type Query struct {
 	// identity skipchain simulation
 	IVSigs    QueryIVSigs
 	RosterVNs *onet.Roster
-
-	// if real DB at data providers
-	SQL QuerySQL
 
 	//simulation
 	CuttingFactor int

--- a/protocols/data_collection_protocol_test.go
+++ b/protocols/data_collection_protocol_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ldsec/drynx/lib"
+	"github.com/ldsec/drynx/lib/provider/loaders"
 	"github.com/ldsec/drynx/protocols"
 	"github.com/ldsec/unlynx/lib"
 	"github.com/stretchr/testify/assert"
@@ -93,9 +94,13 @@ func TestDataCollectionOperationsProtocol(t *testing.T) {
 
 // NewDataCollectionTest is a test specific protocol instance constructor that injects test data.
 func NewDataCollectionTest(tni *onet.TreeNodeInstance) (onet.ProtocolInstance, error) {
-	pi, err := protocols.NewDataCollectionProtocol(tni)
-	protocol := pi.(*protocols.DataCollectionProtocol)
+	loader, err := loaders.NewRandom()
+	if err != nil {
+		return nil, err
+	}
 
-	protocol.Survey = query
-	return protocol, err
+	dcp := protocols.NewDataCollectionProtocol(loader)
+	dcp.Survey = query
+	dcp.ProtocolRegister(tni)
+	return &dcp, nil
 }

--- a/protocols/proof_collection_protocol.go
+++ b/protocols/proof_collection_protocol.go
@@ -1,10 +1,10 @@
 package protocols
 
 import (
+	"errors"
 	"github.com/ldsec/drynx/lib/proof"
 	"sync"
 
-	"github.com/btcsuite/goleveldb/leveldb/errors"
 	"github.com/coreos/bbolt"
 	"github.com/fanliao/go-concurrentMap"
 	"github.com/ldsec/drynx/lib"

--- a/services/api.go
+++ b/services/api.go
@@ -62,14 +62,10 @@ func (c *API) GenerateSurveyQuery(rosterServers, rosterVNs *onet.Roster, dpToSer
 
 	iVSigs := libdrynx.QueryIVSigs{InputValidationSigs: ps, InputValidationSize1: size1, InputValidationSize2: size2}
 
-	test := make([][]int64, 0)
-	test = append(test, []int64{int64(1)})
-
 	//create the query
 	sq := libdrynx.SurveyQuery{
 		SurveyID:                   surveyID,
 		RosterServers:              *rosterServers,
-		ClientPubKey:               c.public,
 		IntraMessage:               false,
 		ServerToDP:                 dpToServer,
 		IDtoPublic:                 idToPublic,
@@ -101,6 +97,10 @@ func (c *API) GenerateSurveyQuery(rosterServers, rosterVNs *onet.Roster, dpToSer
 // SendSurveyQuery creates a survey based on a set of entities (servers) and a survey description.
 func (c *API) SendSurveyQuery(sq libdrynx.SurveyQuery) (*[]string, *[][]float64, error) {
 	log.Lvl2("[API] <Drynx> Client", c.clientID, "is creating a query with SurveyID: ", sq.SurveyID)
+
+	if sq.ClientPubKey == nil {
+		sq.ClientPubKey = c.public
+	}
 
 	//send the query and get the answer
 	sr := libdrynx.ResponseDP{}

--- a/services/api.go
+++ b/services/api.go
@@ -25,18 +25,15 @@ type API struct {
 	private    kyber.Scalar
 }
 
-//init of the network messages
-func init() {
+// NewDrynxClient constructor of a client.
+func NewDrynxClient(entryPoint *network.ServerIdentity, clientID string) *API {
 	network.RegisterMessage(libdrynx.GetLatestBlock{})
 	network.RegisterMessage(libdrynxrange.RangeProofListBytes{})
 	network.RegisterMessage(libunlynxshuffle.PublishedShufflingProofBytes{})
 	network.RegisterMessage(libunlynxkeyswitch.PublishedKSListProofBytes{})
 	network.RegisterMessage(libunlynxaggr.PublishedAggregationListProofBytes{})
 	network.RegisterMessage(libdrynxobfuscation.PublishedListObfuscationProofBytes{})
-}
 
-// NewDrynxClient constructor of a client.
-func NewDrynxClient(entryPoint *network.ServerIdentity, clientID string) *API {
 	keys := key.NewKeyPair(libunlynx.SuiTe)
 	newClient := &API{
 		Client:     onet.NewClient(libdrynx.Suite, ServiceName),

--- a/services/api_skipchain.go
+++ b/services/api_skipchain.go
@@ -1,7 +1,8 @@
 package services
 
 import (
-	"github.com/btcsuite/goleveldb/leveldb/errors"
+	"errors"
+
 	"github.com/ldsec/drynx/lib"
 	"go.dedis.ch/cothority/v3/skipchain"
 	"go.dedis.ch/onet/v3"

--- a/services/builder.go
+++ b/services/builder.go
@@ -1,0 +1,128 @@
+package services
+
+import (
+	"sync"
+
+	"github.com/fanliao/go-concurrentMap"
+	"go.dedis.ch/cothority/v3/skipchain"
+	"go.dedis.ch/onet/v3"
+	"go.dedis.ch/onet/v3/log"
+	onet_network "go.dedis.ch/onet/v3/network"
+
+	"github.com/ldsec/drynx/lib"
+	"github.com/ldsec/drynx/lib/provider"
+	"github.com/ldsec/drynx/protocols"
+)
+
+type builderDataProvider struct {
+	loader provider.Loader
+}
+
+// Builder is the state of node creation.
+type Builder struct {
+	dataProvider *builderDataProvider
+}
+
+// NewBuilder allow to create a node.
+func NewBuilder() Builder {
+	return Builder{}
+}
+
+// WithComputingNode add support for running as a Computing Node.
+func (b Builder) WithComputingNode() Builder {
+	// TODO split
+	msgTypes.msgSurveyQuery = onet_network.RegisterMessage(&libdrynx.SurveyQuery{})
+	msgTypes.msgSurveyQueryToDP = onet_network.RegisterMessage(&libdrynx.SurveyQueryToDP{})
+	msgTypes.msgDPqueryReceived = onet_network.RegisterMessage(&DPqueryReceived{})
+	msgTypes.msgSyncDCP = onet_network.RegisterMessage(&SyncDCP{})
+	msgTypes.msgDPdataFinished = onet_network.RegisterMessage(&DPdataFinished{})
+
+	onet_network.RegisterMessage(&libdrynx.SurveyQueryToVN{})
+	onet_network.RegisterMessage(&libdrynx.ResponseDP{})
+
+	onet_network.RegisterMessage(&libdrynx.EndVerificationRequest{})
+
+	onet_network.RegisterMessage(libdrynx.DataBlock{})
+	onet_network.RegisterMessage(&libdrynx.GetLatestBlock{})
+	onet_network.RegisterMessage(&libdrynx.GetGenesis{})
+	onet_network.RegisterMessage(&libdrynx.GetBlock{})
+	onet_network.RegisterMessage(&libdrynx.GetProofs{})
+	onet_network.RegisterMessage(&libdrynx.CloseDB{})
+	return b
+}
+
+// WithDataProvider add support for running as a Data Provider.
+func (b Builder) WithDataProvider(loader provider.Loader) Builder {
+	onet_network.RegisterMessage(protocols.AnnouncementDCMessage{})
+	onet_network.RegisterMessage(protocols.DataCollectionMessage{})
+
+	dcp := protocols.NewDataCollectionProtocol(loader)
+	_, err := onet.GlobalProtocolRegister(protocols.DataCollectionProtocolName, dcp.ProtocolRegister)
+	if err != nil {
+		log.Fatal("Error registering <DataCollectionProtocol>:", err)
+	}
+
+	b.dataProvider = &builderDataProvider{loader}
+	return b
+}
+
+// WithVerifyingNode add support for running as a Verifying Node.
+func (b Builder) WithVerifyingNode() Builder {
+	return b
+}
+
+// Start actually starts the node. You still have to start the onet server.
+func (b Builder) Start() {
+	var loader provider.Loader
+	if b.dataProvider != nil {
+		loader = b.dataProvider.loader
+	}
+
+	_, err := onet.RegisterNewService(ServiceName, func(c *onet.Context) (onet.Service, error) {
+		newDrynxInstance := &ServiceDrynx{
+			ServiceProcessor: onet.NewServiceProcessor(c),
+			Survey:           concurrent.NewConcurrentMap(),
+			Mutex:            &sync.Mutex{},
+			loader:           loader,
+		}
+
+		registerHandler := func(handler interface{}) {
+			if err := newDrynxInstance.RegisterHandler(handler); err != nil {
+				log.Fatal("[SERVICE] <drynx> Server, Wrong Handler.", err)
+			}
+		}
+
+		registerHandler(newDrynxInstance.HandleSurveyQuery)
+		registerHandler(newDrynxInstance.HandleSurveyQueryToDP)
+		registerHandler(newDrynxInstance.HandleSurveyQueryToVN)
+		if waitOnLocalChans {
+			registerHandler(newDrynxInstance.HandleDPqueryReceived)
+			registerHandler(newDrynxInstance.HandleSyncDCP)
+			registerHandler(newDrynxInstance.HandleDPdataFinished)
+		}
+		registerHandler(newDrynxInstance.HandleEndVerification)
+		registerHandler(newDrynxInstance.HandleGetLatestBlock)
+		registerHandler(newDrynxInstance.HandleGetGenesis)
+		registerHandler(newDrynxInstance.HandleGetBlock)
+		registerHandler(newDrynxInstance.HandleGetProofs)
+		registerHandler(newDrynxInstance.HandleCloseDB)
+
+		c.RegisterProcessor(newDrynxInstance, msgTypes.msgSurveyQuery)
+		c.RegisterProcessor(newDrynxInstance, msgTypes.msgSurveyQueryToDP)
+		if waitOnLocalChans {
+			c.RegisterProcessor(newDrynxInstance, msgTypes.msgDPqueryReceived)
+			c.RegisterProcessor(newDrynxInstance, msgTypes.msgSyncDCP)
+			c.RegisterProcessor(newDrynxInstance, msgTypes.msgDPdataFinished)
+		}
+
+		//Register new verifFunction
+		if err := skipchain.RegisterVerification(c, VerifyBitmap, newDrynxInstance.verifyFuncBitmap); err != nil {
+			return nil, err
+		}
+
+		return newDrynxInstance, nil
+	})
+	if err != nil {
+		log.Fatal("Error registering service:", err)
+	}
+}

--- a/services/service_test.go
+++ b/services/service_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/ldsec/drynx/lib"
 	"github.com/ldsec/drynx/lib/encoding"
+	"github.com/ldsec/drynx/lib/provider/loaders"
 	"github.com/ldsec/drynx/lib/range"
 	"github.com/ldsec/drynx/services"
 	"github.com/ldsec/unlynx/lib"
@@ -23,6 +24,16 @@ import (
 )
 
 func generateNodes(local *onet.LocalTest, nbrServers int, nbrDPs int, nbrVNs int) (*onet.Roster, *onet.Roster, *onet.Roster) {
+	loader, err := loaders.NewRandom()
+	if err != nil {
+		panic(err)
+	}
+	services.NewBuilder().
+		WithComputingNode().
+		WithDataProvider(loader).
+		WithVerifyingNode().
+		Start()
+
 	_, elTotal, _ := local.GenTree(nbrServers+nbrDPs+nbrVNs, true)
 
 	// create servers and data providers

--- a/simul/drynx_simul.go
+++ b/simul/drynx_simul.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/ldsec/drynx/lib"
+	"github.com/ldsec/drynx/lib/provider/loaders"
 	"github.com/ldsec/drynx/services"
 	"github.com/ldsec/unlynx/lib"
 	"go.dedis.ch/cothority/v3/skipchain"
@@ -21,6 +22,16 @@ import (
 )
 
 func init() {
+	loader, err := loaders.NewRandom()
+	if err != nil {
+		panic(err)
+	}
+	services.NewBuilder().
+		WithComputingNode().
+		WithDataProvider(loader).
+		WithVerifyingNode().
+		Start()
+
 	onet.SimulationRegister("ServiceDrynx", NewSimulationDrynx)
 }
 

--- a/test/client_run-survey
+++ b/test/client_run-survey
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 . ./lib.sh
 
-start_nodes
+cat > providing <<EOF
+1
+2
+3
+EOF
+
+start_nodes providing
 
 (
 	client_gen_network
 	client survey new test-run-survey |
-		client survey set-operation mean
-) | client survey run
+		client survey set-operation sum
+) | client survey run |
+	xargs test $(((1+2+3) * (node_count-1))) -eq

--- a/test/client_select-correct-column
+++ b/test/client_select-correct-column
@@ -16,4 +16,4 @@ start_nodes providing
 		client survey set-sources col2 |
 		client survey set-operation sum
 ) | client survey run |
-	xargs test $(((4+5+6) * (node_count-1))) -eq
+	xargs -t test $(((4+5+6) * (node_count-1))) -eq

--- a/test/client_select-two-correct-columns
+++ b/test/client_select-two-correct-columns
@@ -2,10 +2,10 @@
 . ./lib.sh
 
 cat > providing <<EOF
-col1	col2
-1	4
-2	5
-3	6
+col1	col2	col3
+1	4	-2
+2	5	-4
+3	6	-6
 EOF
 
 start_nodes providing
@@ -13,7 +13,7 @@ start_nodes providing
 (
 	client_gen_network
 	client survey new test-run-survey |
-		client survey set-sources col2 |
-		client survey set-operation sum
+		client survey set-sources col{1,3} |
+		client survey set-operation cosim
 ) | client survey run |
-	xargs test $(((4+5+6) * (node_count-1))) -eq
+	xargs -t test -0.9999999999999999 =

--- a/test/client_set-unknown-source
+++ b/test/client_set-unknown-source
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+. ./lib.sh
+
+cat > providing <<EOF
+name
+1
+2
+3
+EOF
+
+start_nodes providing
+
+(
+	client_gen_network
+	client survey new test |
+		client survey set-sources unknown |
+		client survey set-operation sum
+) | client survey run |
+	xargs test 0 -eq

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -34,6 +34,11 @@ cleanup() {
 	exit $err
 }
 
+fail() {
+	echo $@
+	exit 1
+}
+
 readonly port_base=$((RANDOM + 1024))
 readonly port_top=$((port_base + 2*node_count - 1))
 nodes=''

--- a/test/server_conf-and-run
+++ b/test/server_conf-and-run
@@ -2,3 +2,7 @@
 . ./lib.sh
 
 start_nodes
+
+get_nodes |
+	cut -d ' ' -f 1 | tr : ' ' |
+	xargs -n2 nc -q 0

--- a/test/server_exit-with-err-on-missing-args
+++ b/test/server_exit-with-err-on-missing-args
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+. ./lib.sh
+
+server new &&
+	fail 'should exit != 0 on missing args' || :


### PR DESCRIPTION
* add `client survey set-sources` to select column to operate upon
* allow server to have flavors, ie choosing between/a mix of DataProvider, ComputingNode or VerificationNode via `server {{verifying,computing}-node, data-provider} new`
  * currently acting as before (all together), it's to flavor DataProvider specifically
* add a service builder, to be able to select these flavors
* add an interface, `lib/provider.Loader`, to have potentially many provider implementation (currently: random and file backed)
* removed unused `lib.QuerySQL`