### PR TITLE
Use gonum's matrix

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -276,6 +276,7 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.6.0 h1:DJy6UzXbahnGUf1ujUNkh/NEtK14qMo2nvlBPs4U5yw=
 gonum.org/v1/gonum v0.6.0/go.mod h1:9mxDZsDKxgMAuccQkewq682L+0eCu4dCN2yonUJTCLU=
+gonum.org/v1/gonum v0.7.0 h1:Hdks0L0hgznZLG9nzXb8vZ0rRvqNvAcgAp84y7Mwkgw=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0 h1:OE9mWmgKkjJyEmDAAtGMPjXu+YNeGvK9VTSHY6+Qihc=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/plot v0.0.0-20190515093506-e2840ee46a6b/go.mod h1:Wt8AAjI+ypCyYX3nZBvf6cAIx93T+c/OS2HFAYskSZc=

--- a/lib/encoding/logistic_regression.go
+++ b/lib/encoding/logistic_regression.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/montanaflynn/stats"
 	"gonum.org/v1/gonum/integrate"
+	"gonum.org/v1/gonum/mat"
 	"gonum.org/v1/gonum/stat"
 	"gonum.org/v1/gonum/stat/combin"
 )
@@ -1576,4 +1577,57 @@ func Float64ToInt642DArrayWithPrecision(arrayFloat64 [][]float64, precision floa
 // Round rounds a float number to the nearest <unit> digits
 func Round(x, unit float64) float64 {
 	return math.Round(x/unit) * unit
+}
+
+// MatrixToFloat2D converts a mat.Matrix to a [][]float64
+func MatrixToFloat2D(matrix mat.Matrix) [][]float64 {
+	rowCount, columnCount := matrix.Dims()
+
+	ret := make([][]float64, rowCount)
+	for i := range ret {
+		row := make([]float64, columnCount)
+		for j := range row {
+			row[j] = matrix.At(i, j)
+		}
+		ret[i] = row
+	}
+
+	return ret
+}
+
+// Float2DToMatrix converts a rectangular [][]float64 to mat.Dense
+func Float2DToMatrix(matrix [][]float64) *mat.Dense {
+	rowCount, columnCount := len(matrix), len(matrix[0])
+
+	ret := mat.NewDense(rowCount, columnCount, nil)
+	for i, row := range matrix {
+		for j, v := range row {
+			ret.Set(i, j, v)
+		}
+	}
+
+	return ret
+}
+
+// VectorToInt converts a mat.Vector to a []int64
+func VectorToInt(vector mat.Vector) []int64 {
+	ret := make([]int64, vector.Len())
+	for i := range ret {
+		ret[i] = int64(vector.AtVec(i))
+	}
+	return ret
+}
+
+// VectorToFloat converts a mat.Vector to a []float64
+func VectorToFloat(vector mat.Vector) []float64 {
+	ret := make([]float64, vector.Len())
+	for i := range ret {
+		ret[i] = vector.AtVec(i)
+	}
+	return ret
+}
+
+// FloatToVector converts a []float64 to mat.VecDense
+func FloatToVector(vector []float64) *mat.VecDense {
+	return mat.NewVecDense(len(vector), vector)
 }

--- a/lib/encoding/logistic_regression.go
+++ b/lib/encoding/logistic_regression.go
@@ -70,10 +70,10 @@ func EncodeLogisticRegression(xData [][]float64, yData []int64, lrParameters lib
 			log.Lvl2("Standardising the training set with local means and standard deviations...")
 			Standardise(X)
 		}
-		XStandardised := MatrixToFloat2D(X)
 
 		// add an all 1s column to the data (offset term)
-		XStandardised = Augment(XStandardised)
+		X = Augment(X)
+		XStandardised := MatrixToFloat2D(X)
 
 		N := lrParameters.NbrRecords
 		// compute all approximation coefficients per record
@@ -150,10 +150,10 @@ func EncodeLogisticRegressionWithProofs(xData [][]float64, yData []int64, lrPara
 			log.Lvl2("Standardising the training set with local means and standard deviations...")
 			Standardise(X)
 		}
-		XStandardised := MatrixToFloat2D(X)
 
 		// add an all 1s column to the data (offset term)
-		XStandardised = Augment(XStandardised)
+		X = Augment(X)
+		XStandardised := MatrixToFloat2D(X)
 
 		N := lrParameters.NbrRecords
 
@@ -980,15 +980,18 @@ func NormalizeWith(matrixTest *mat.Dense, matrixTrain mat.Matrix) {
 }
 
 // Augment returns the given 2D array with an additional all 1's column prepended as the first column
-func Augment(matrix [][]float64) [][]float64 {
-	column := make([]float64, len(matrix))
-	for i := 0; i < len(matrix); i++ {
-		column[i] = 1
+func Augment(matrix mat.Matrix) *mat.Dense {
+	rowCount, columnCount := matrix.Dims()
+	ret := mat.NewDense(rowCount, columnCount+1, nil)
+
+	augment := mat.NewVecDense(rowCount, nil)
+	for i := 0; i < rowCount; i++ {
+		augment.SetVec(i, 1)
 	}
 
-	matrix = InsertColumn(matrix, column, 0)
+	ret.Augment(augment, matrix)
 
-	return matrix
+	return ret
 }
 
 // returns the given 2D array flattened into a 1D array

--- a/lib/encoding/logistic_regression.go
+++ b/lib/encoding/logistic_regression.go
@@ -904,18 +904,20 @@ func PredictHomomorphic(encryptedData libunlynx.CipherVector, weights []float64,
 //--------------------
 
 // ComputeMeans returns the means of each column of the given data matrix
-func ComputeMeans(data [][]float64) ([]float64, error) {
-	means := make([]float64, len(data[0]))
+func ComputeMeans(matrix mat.Matrix) []float64 {
+	rowCount, columnCount := matrix.Dims()
 
+	means := make([]float64, columnCount)
 	for i := range means {
-		feature, err := GetColumn(data, uint(i))
-		if err != nil {
-			return nil, err
+		column := make([]float64, rowCount)
+		for j := range column {
+			column[j] = matrix.At(j, i)
 		}
-		means[i], _ = stats.Mean(feature)
+
+		means[i] = stat.Mean(column, nil)
 	}
 
-	return means, nil
+	return means
 }
 
 // ComputeStandardDeviations returns the standard deviation of each column of the given data matrix
@@ -945,10 +947,8 @@ func StandardiseWithTrain(matrixTest, matrixTrain [][]float64) ([][]float64, err
 	if err != nil {
 		return nil, err
 	}
-	means, err := ComputeMeans(matrixTrain)
-	if err != nil {
-		return nil, err
-	}
+
+	means := ComputeMeans(Float2DToMatrix(matrixTrain))
 
 	standardisedMatrix := make([][]float64, len(matrixTest))
 	for i, record := range matrixTest {

--- a/lib/encoding/logistic_regression.go
+++ b/lib/encoding/logistic_regression.go
@@ -921,18 +921,20 @@ func ComputeMeans(matrix mat.Matrix) []float64 {
 }
 
 // ComputeStandardDeviations returns the standard deviation of each column of the given data matrix
-func ComputeStandardDeviations(data [][]float64) ([]float64, error) {
-	standardDeviations := make([]float64, len(data[0]))
+func ComputeStandardDeviations(matrix mat.Matrix) []float64 {
+	rowCount, columnCount := matrix.Dims()
 
+	standardDeviations := make([]float64, columnCount)
 	for i := range standardDeviations {
-		feature, err := GetColumn(data, uint(i))
-		if err != nil {
-			return nil, err
+		column := make([]float64, rowCount)
+		for j := range column {
+			column[j] = matrix.At(j, i)
 		}
-		standardDeviations[i], _ = stats.StandardDeviation(feature)
+
+		standardDeviations[i] = stat.StdDev(column, nil)
 	}
 
-	return standardDeviations, nil
+	return standardDeviations
 }
 
 // Standardise returns the standardized 2D array version of the given 2D array
@@ -943,11 +945,7 @@ func Standardise(matrix [][]float64) ([][]float64, error) {
 
 // StandardiseWithTrain standardises a matrix with the given matrix means and standard deviations
 func StandardiseWithTrain(matrixTest, matrixTrain [][]float64) ([][]float64, error) {
-	sds, err := ComputeStandardDeviations(matrixTrain)
-	if err != nil {
-		return nil, err
-	}
-
+	sds := ComputeStandardDeviations(Float2DToMatrix(matrixTrain))
 	means := ComputeMeans(Float2DToMatrix(matrixTrain))
 
 	standardisedMatrix := make([][]float64, len(matrixTest))

--- a/lib/encoding/logistic_regression.go
+++ b/lib/encoding/logistic_regression.go
@@ -53,11 +53,6 @@ func EncodeLogisticRegression(xData [][]float64, yData []int64, lrParameters lib
 	encryptedAggregatedApproxCoefficients := make([]libunlynx.CipherText, n)
 
 	if xData != nil && len(xData) > 0 {
-		// unpack the data into features and labels
-		/*labelColumn := 0
-		X := RemoveColumn(data, labelColumn)
-		y := Float64ToInt641DArray(GetColumn(data, labelColumn))*/
-
 		// standardise the data
 		X := Float2DToMatrix(xData)
 		if lrParameters.Means != nil && lrParameters.StandardDeviations != nil &&
@@ -133,11 +128,6 @@ func EncodeLogisticRegressionWithProofs(xData [][]float64, yData []int64, lrPara
 	encryptedAggregatedApproxCoefficientsOnlyCipher := make([]libunlynx.CipherText, n)
 
 	if xData != nil && len(xData) > 0 {
-		// unpack the data into features and labels
-		/*labelColumn := 0
-		X := RemoveColumn(data, labelColumn)
-		y := Float64ToInt641DArray(GetColumn(data, labelColumn))*/
-
 		// standardise the data
 		X := Float2DToMatrix(xData)
 		if lrParameters.Means != nil && lrParameters.StandardDeviations != nil &&
@@ -1299,39 +1289,6 @@ func ReadFile(path string, separator rune) (*mat.Dense, error) {
 	}
 
 	return mat.NewDense(lineCount, reader.FieldsPerRecord, records), nil
-}
-
-// GetColumn returns the column at index <idx> in the given 2D array <matrix>
-func GetColumn(matrix [][]float64, idx uint) ([]float64, error) {
-	if len(matrix) < 0 {
-		return nil, errors.New("empty matrix")
-	}
-	if idx >= uint(len(matrix[0])) {
-		return nil, errors.New("column index exceeds matrix dimension")
-	}
-
-	array := make([]float64, len(matrix))
-	for i := range matrix {
-		array[i] = matrix[i][idx]
-	}
-
-	return array, nil
-}
-
-// RemoveColumn returns a 2D array with the column at index <idx> removed from the given 2D array <matrix>
-func RemoveColumn(matrix [][]float64, idx uint) ([][]float64, error) {
-	if idx >= uint(len(matrix[0])) {
-		return nil, errors.New("column index exceeds matrix dimension")
-	}
-
-	truncatedMatrix := make([][]float64, len(matrix))
-	for i := range matrix {
-		//truncatedMatrix[i] = make([]float64, len(matrix[i]) - 1)
-		truncatedMatrix[i] = append(truncatedMatrix[i], matrix[i][:idx]...)
-		truncatedMatrix[i] = append(truncatedMatrix[i], matrix[i][idx+1:]...)
-	}
-
-	return truncatedMatrix, nil
 }
 
 // ReplaceString replaces all strings <old> by string <new> in the given string matrix

--- a/lib/encoding/logistic_regression_dataset_test.go
+++ b/lib/encoding/logistic_regression_dataset_test.go
@@ -437,8 +437,10 @@ func TestFindMinimumWeightsForSPECTF(t *testing.T) {
 	log.Lvl2("-------------------------------")
 
 	parameters, _, preprocessing, SPECTFTraining, _, _, precisionApproxCoefficients, _, _ := getParametersForSPECTF()
-	X, y, err := libdrynxencoding.LoadData("SPECTF", SPECTFTraining)
+	matrix, vector, err := libdrynxencoding.LoadData("SPECTF", SPECTFTraining)
 	require.NoError(t, err)
+
+	X, y := libdrynxencoding.MatrixToFloat2D(matrix), libdrynxencoding.VectorToInt(vector)
 
 	require.NoError(t, compareFindMinimumWeights(X, y, parameters, preprocessing, false, precisionApproxCoefficients, SPECTFpaperWeightsWithoutEncryption))
 }
@@ -448,8 +450,10 @@ func TestFindMinimumWeightsWithEncryptionForSPECTF(t *testing.T) {
 	log.Lvl2("-----------------------------------------------")
 
 	parameters, _, preprocessing, SPECTFTraining, _, _, precisionApproxCoefficients, _, _ := getParametersForSPECTF()
-	X, y, err := libdrynxencoding.LoadData("SPECTF", SPECTFTraining)
+	matrix, vector, err := libdrynxencoding.LoadData("SPECTF", SPECTFTraining)
 	require.NoError(t, err)
+
+	X, y := libdrynxencoding.MatrixToFloat2D(matrix), libdrynxencoding.VectorToInt(vector)
 
 	require.NoError(t, compareFindMinimumWeights(X, y, parameters, preprocessing, true, precisionApproxCoefficients, SPECTFpaperWeightsWithEncryption))
 }
@@ -458,14 +462,17 @@ func predictForSPECTF(weights []float64, withEncryption bool) error {
 	parameters, _, preprocessing, SPECTFTraining, SPECTFTesting, _, precisionApproxCoefficients,
 		precisionData, precisionWeights := getParametersForSPECTF()
 
-	Xtrain, ytrain, err := libdrynxencoding.LoadData("SPECTF", SPECTFTraining)
+	trainMatrix, trainVector, err := libdrynxencoding.LoadData("SPECTF", SPECTFTraining)
 	if err != nil {
 		return err
 	}
-	Xtest, ytest, err := libdrynxencoding.LoadData("SPECTF", SPECTFTesting)
+	testMatrix, testVector, err := libdrynxencoding.LoadData("SPECTF", SPECTFTesting)
 	if err != nil {
 		return err
 	}
+
+	Xtrain, ytrain := libdrynxencoding.MatrixToFloat2D(trainMatrix), libdrynxencoding.VectorToInt(trainVector)
+	Xtest, ytest := libdrynxencoding.MatrixToFloat2D(testMatrix), libdrynxencoding.VectorToInt(testVector)
 
 	accuracy, precision, recall, fscore, auc, err := predict(Xtrain, ytrain, Xtest, ytest, weights, parameters,
 		preprocessing, withEncryption, precisionApproxCoefficients, precisionData, precisionWeights)
@@ -499,8 +506,9 @@ func TestPredictForSPECTFRandom(t *testing.T) {
 
 	numberTrials := 1 //10
 	initSeed := int64(5432109876)
-	X, y, err := libdrynxencoding.LoadData("SPECTF", SPECTFAll)
+	matrix, vector, err := libdrynxencoding.LoadData("SPECTF", SPECTFAll)
 	require.NoError(t, err)
+	X, y := libdrynxencoding.MatrixToFloat2D(matrix), libdrynxencoding.VectorToInt(vector)
 
 	require.NoError(t, predictWithRandomSplit(X, y, nil, ratio, parameters, preprocessing, precisionApproxCoefficients, precisionData,
 		precisionWeights, false, numberTrials, initSeed))
@@ -545,10 +553,13 @@ func TestPredictForSPECTFWithGoml(t *testing.T) {
 	}
 
 	parameters, _, _, SPECTFTraining, SPECTFTesting, _, _, _, _ := getParametersForSPECTF()
-	Xtrain, ytrain, err := libdrynxencoding.LoadData("SPECTF", SPECTFTraining)
+	trainMatrix, trainVector, err := libdrynxencoding.LoadData("SPECTF", SPECTFTraining)
 	require.NoError(t, err)
-	Xtest, ytest, err := libdrynxencoding.LoadData("SPECTF", SPECTFTesting)
+	testMatrix, testVector, err := libdrynxencoding.LoadData("SPECTF", SPECTFTesting)
 	require.NoError(t, err)
+
+	Xtrain, ytrain := libdrynxencoding.MatrixToFloat2D(trainMatrix), libdrynxencoding.VectorToInt(trainVector)
+	Xtest, ytest := libdrynxencoding.MatrixToFloat2D(testMatrix), libdrynxencoding.VectorToInt(testVector)
 
 	model := linear.NewLogistic(base.BatchGA, parameters.step, parameters.lambda, parameters.maxIterations, Xtrain,
 		libdrynxencoding.Int64ToFloat641DArray(ytrain))
@@ -589,8 +600,11 @@ func TestLPredictForSPECTFRandomWtihGoml(t *testing.T) {
 	}
 
 	parameters, _, _, _, path, _, _, _, _ := getParametersForSPECTF()
-	X, y, err := libdrynxencoding.LoadData("SPECTF", path)
+	matrix, vector, err := libdrynxencoding.LoadData("SPECTF", path)
 	require.NoError(t, err)
+
+	X, y := libdrynxencoding.MatrixToFloat2D(matrix), libdrynxencoding.VectorToInt(vector)
+
 	predictGoml(X, y, 0.3, parameters, 1000, int64(5432109876))
 }
 
@@ -640,8 +654,9 @@ func TestFindMinimumWeightsForPima(t *testing.T) {
 	log.Lvl2("-----------------------------")
 
 	parameters, _, preprocessing, path, precisionApproxCoefficieents, _, _ := getParametersForPima()
-	X, y, err := libdrynxencoding.LoadData("Pima", path)
+	matrix, vector, err := libdrynxencoding.LoadData("Pima", path)
 	require.NoError(t, err)
+	X, y := libdrynxencoding.MatrixToFloat2D(matrix), libdrynxencoding.VectorToInt(vector)
 	require.NoError(t, compareFindMinimumWeights(X, y, parameters, preprocessing, false, precisionApproxCoefficieents, PimaPaperWeightsWithoutEncryption))
 }
 
@@ -654,8 +669,9 @@ func TestFindMinimumWeightsWithEncryptionForPima(t *testing.T) {
 	log.Lvl2("---------------------------------------------")
 
 	parameters, _, preprocessing, path, precisionApproxCoefficients, _, _ := getParametersForPima()
-	X, y, err := libdrynxencoding.LoadData("Pima", path)
+	matrix, vector, err := libdrynxencoding.LoadData("Pima", path)
 	require.NoError(t, err)
+	X, y := libdrynxencoding.MatrixToFloat2D(matrix), libdrynxencoding.VectorToInt(vector)
 	require.NoError(t, compareFindMinimumWeights(X, y, parameters, preprocessing, true, precisionApproxCoefficients, PimaPaperWeightsWithEncryption))
 }
 
@@ -671,8 +687,10 @@ func TestPredictForPima(t *testing.T) {
 		precisionWeights := getParametersForPima()
 	numberTrials := 10
 	initSeed := int64(5432109876)
-	X, y, err := libdrynxencoding.LoadData("Pima", path)
+	matrix, vector, err := libdrynxencoding.LoadData("Pima", path)
 	require.NoError(t, err)
+
+	X, y := libdrynxencoding.MatrixToFloat2D(matrix), libdrynxencoding.VectorToInt(vector)
 
 	require.NoError(t, predictWithRandomSplit(X, y, nil, ratio, parameters, preprocessing, precisionApproxCoefficients, precisionData,
 		precisionWeights, false, numberTrials, initSeed))
@@ -690,8 +708,10 @@ func TestPredictWithEncryptionForPima(t *testing.T) {
 		precisionWeights := getParametersForPima()
 	numberTrials := 10
 	initSeed := int64(5432109876)
-	X, y, err := libdrynxencoding.LoadData("Pima", path)
+	matrix, vector, err := libdrynxencoding.LoadData("Pima", path)
 	require.NoError(t, err)
+
+	X, y := libdrynxencoding.MatrixToFloat2D(matrix), libdrynxencoding.VectorToInt(vector)
 
 	require.NoError(t, predictWithRandomSplit(X, y, nil, ratio, parameters, preprocessing, precisionApproxCoefficients, precisionData,
 		precisionWeights, true, numberTrials, initSeed))
@@ -709,8 +729,10 @@ func TestPredictForPimaPaper(t *testing.T) {
 		precisionWeights := getParametersForPima()
 	numberTrials := 10
 	initSeed := int64(5432109876)
-	X, y, err := libdrynxencoding.LoadData("Pima", path)
+	matrix, vector, err := libdrynxencoding.LoadData("Pima", path)
 	require.NoError(t, err)
+
+	X, y := libdrynxencoding.MatrixToFloat2D(matrix), libdrynxencoding.VectorToInt(vector)
 
 	require.NoError(t, predictWithRandomSplit(X, y, PimaPaperWeightsWithoutEncryption, ratio, parameters, preprocessing,
 		precisionApproxCoefficients, precisionData, precisionWeights,
@@ -732,8 +754,10 @@ func TestPredictForPimaMatlab(t *testing.T) {
 		precisionWeights := getParametersForPima()
 	numberTrials := 10
 	initSeed := int64(5432109876)
-	X, y, err := libdrynxencoding.LoadData("Pima", path)
+	matrix, vector, err := libdrynxencoding.LoadData("Pima", path)
 	require.NoError(t, err)
+
+	X, y := libdrynxencoding.MatrixToFloat2D(matrix), libdrynxencoding.VectorToInt(vector)
 
 	require.NoError(t, predictWithRandomSplit(X, y, PimaMatlabWeights, ratio, parameters, preprocessing, precisionApproxCoefficients,
 		precisionData, precisionWeights,
@@ -751,8 +775,10 @@ func TestPredictWithEncryptionForPimaPaper(t *testing.T) {
 	parameters, ratio, preprocessing, path, precisionApproxCoefficients, precisionData, precisionWeights := getParametersForPima()
 	numberTrials := 10
 	initSeed := int64(5432109876)
-	X, y, err := libdrynxencoding.LoadData("Pima", path)
+	matrix, vector, err := libdrynxencoding.LoadData("Pima", path)
 	require.NoError(t, err)
+
+	X, y := libdrynxencoding.MatrixToFloat2D(matrix), libdrynxencoding.VectorToInt(vector)
 
 	require.NoError(t, predictWithRandomSplit(X, y, PimaPaperWeightsWithEncryption, ratio, parameters, preprocessing,
 		precisionApproxCoefficients, precisionData, precisionWeights,
@@ -765,8 +791,11 @@ func TestPredictForPimaWithGoml(t *testing.T) {
 	}
 
 	parameters, ratio, _, path, _, _, _ := getParametersForPima()
-	X, y, err := libdrynxencoding.LoadData("Pima", path)
+	matrix, vector, err := libdrynxencoding.LoadData("Pima", path)
 	require.NoError(t, err)
+
+	X, y := libdrynxencoding.MatrixToFloat2D(matrix), libdrynxencoding.VectorToInt(vector)
+
 	predictGoml(X, y, ratio, parameters, 10, int64(5432109876))
 }
 
@@ -805,8 +834,9 @@ func TestPredictForPCS(t *testing.T) {
 		precisionWeights := getParametersForPCS()
 	numberTrials := 10
 	initSeed := int64(5432109876)
-	X, y, err := libdrynxencoding.LoadData("PCS", path)
+	matrix, vector, err := libdrynxencoding.LoadData("PCS", path)
 	require.NoError(t, err)
+	X, y := libdrynxencoding.MatrixToFloat2D(matrix), libdrynxencoding.VectorToInt(vector)
 
 	require.NoError(t, predictWithRandomSplit(X, y, nil, ratio, parameters, preprocessing, precisionApproxCoefficients, precisionData,
 		precisionWeights, false, numberTrials, initSeed))
@@ -818,7 +848,8 @@ func TestPredictForPCSWithGoml(t *testing.T) {
 	}
 
 	parameters, ratio, _, path, _, _, _ := getParametersForPCS()
-	X, y, err := libdrynxencoding.LoadData("PCS", path)
+	matrix, vector, err := libdrynxencoding.LoadData("PCS", path)
 	require.NoError(t, err)
+	X, y := libdrynxencoding.MatrixToFloat2D(matrix), libdrynxencoding.VectorToInt(vector)
 	predictGoml(X, y, ratio, parameters, 5, int64(5432109876))
 }

--- a/lib/encoding/logistic_regression_dataset_test.go
+++ b/lib/encoding/logistic_regression_dataset_test.go
@@ -46,8 +46,8 @@ func compareFindMinimumWeights(Xtrain [][]float64, ytrain []int64, parameters Mi
 	initialWeights := parameters.initialWeights
 	X := libdrynxencoding.Float2DToMatrix(Xtrain)
 	libdrynxencoding.Standardise(X)
+	X = libdrynxencoding.Augment(X)
 	Xtrain = libdrynxencoding.MatrixToFloat2D(X)
-	Xtrain = libdrynxencoding.Augment(Xtrain)
 	// data providers part + servers part + client part collapsed here for testing
 
 	var weights []float64
@@ -152,8 +152,8 @@ func predict(Xtrain [][]float64, ytrain []int64,
 	// data pre-processing
 	matrixXTrain := libdrynxencoding.Float2DToMatrix(Xtrain)
 	libdrynxencoding.Standardise(matrixXTrain)
+	matrixXTrain = libdrynxencoding.Augment(matrixXTrain)
 	Xtrain = libdrynxencoding.MatrixToFloat2D(matrixXTrain)
-	Xtrain = libdrynxencoding.Augment(Xtrain)
 
 	// the client's (public key, private key) pair
 	keys := key.NewKeyPair(libunlynx.SuiTe)

--- a/lib/encoding/logistic_regression_dataset_test.go
+++ b/lib/encoding/logistic_regression_dataset_test.go
@@ -82,7 +82,6 @@ func findMinimumWeights(X [][]float64, y []int64, k int, maxIterations int, step
 
 	// each data provider computes its approximation coefficients on its side and then sends them to its chosen server
 	N := len(X)
-	N64 := int64(N)
 	approxCoefficients := make([][][]float64, N)
 	for i := range X {
 		approxCoefficients[i] = libdrynxencoding.ComputeAllApproxCoefficients(X[i], y[i], k)
@@ -91,7 +90,7 @@ func findMinimumWeights(X [][]float64, y []int64, k int, maxIterations int, step
 
 	// the client computes the weights on its side
 	weights := libdrynxencoding.FindMinimumWeights(aggregatedApproxCoefficients,
-		initialWeights, N64,
+		initialWeights, int64(N),
 		lambda, step, maxIterations)
 
 	log.Lvl2("weights 1", weights)

--- a/lib/encoding/logistic_regression_dataset_test.go
+++ b/lib/encoding/logistic_regression_dataset_test.go
@@ -44,10 +44,9 @@ func compareFindMinimumWeights(Xtrain [][]float64, ytrain []int64, parameters Mi
 	step := parameters.step
 	maxIterations := parameters.maxIterations
 	initialWeights := parameters.initialWeights
-	Xtrain, err := libdrynxencoding.Standardise(Xtrain)
-	if err != nil {
-		return err
-	}
+	X := libdrynxencoding.Float2DToMatrix(Xtrain)
+	libdrynxencoding.Standardise(X)
+	Xtrain = libdrynxencoding.MatrixToFloat2D(X)
 	Xtrain = libdrynxencoding.Augment(Xtrain)
 	// data providers part + servers part + client part collapsed here for testing
 
@@ -149,12 +148,12 @@ func predict(Xtrain [][]float64, ytrain []int64,
 
 	// save the original training set in order to standardise the testing set
 	XtrainSaved := Xtrain
+	matrixXTrainSaved := libdrynxencoding.Float2DToMatrix(Xtrain)
 
 	// data pre-processing
-	Xtrain, err := libdrynxencoding.Standardise(Xtrain)
-	if err != nil {
-		return 0, 0, 0, 0, 0, err
-	}
+	matrixXTrain := libdrynxencoding.Float2DToMatrix(Xtrain)
+	libdrynxencoding.Standardise(matrixXTrain)
+	Xtrain = libdrynxencoding.MatrixToFloat2D(matrixXTrain)
 	Xtrain = libdrynxencoding.Augment(Xtrain)
 
 	// the client's (public key, private key) pair
@@ -185,8 +184,11 @@ func predict(Xtrain [][]float64, ytrain []int64,
 
 	// prediction computation
 	// standardise the testing set using the mean and standard deviation of the training set
+	var err error
 	if preprocessing == PREPROCESSING_STANDARDIZE {
-		Xtest, err = libdrynxencoding.StandardiseWithTrain(Xtest, XtrainSaved)
+		matrixXTest := libdrynxencoding.Float2DToMatrix(Xtest)
+		libdrynxencoding.StandardiseWithTrain(matrixXTest, matrixXTrainSaved)
+		Xtest = libdrynxencoding.MatrixToFloat2D(matrixXTest)
 	} else if preprocessing == PREPROCESSING_NORMALIZE {
 		Xtest, err = libdrynxencoding.NormalizeWith(Xtest, XtrainSaved)
 	}

--- a/lib/encoding/logistic_regression_dataset_test.go
+++ b/lib/encoding/logistic_regression_dataset_test.go
@@ -147,8 +147,7 @@ func predict(Xtrain [][]float64, ytrain []int64,
 	log.Lvl2("init:", initialWeights)
 
 	// save the original training set in order to standardise the testing set
-	XtrainSaved := Xtrain
-	matrixXTrainSaved := libdrynxencoding.Float2DToMatrix(Xtrain)
+	XtrainSaved := libdrynxencoding.Float2DToMatrix(Xtrain)
 
 	// data pre-processing
 	matrixXTrain := libdrynxencoding.Float2DToMatrix(Xtrain)
@@ -184,17 +183,13 @@ func predict(Xtrain [][]float64, ytrain []int64,
 
 	// prediction computation
 	// standardise the testing set using the mean and standard deviation of the training set
-	var err error
+	matrixXTest := libdrynxencoding.Float2DToMatrix(Xtest)
 	if preprocessing == PREPROCESSING_STANDARDIZE {
-		matrixXTest := libdrynxencoding.Float2DToMatrix(Xtest)
-		libdrynxencoding.StandardiseWithTrain(matrixXTest, matrixXTrainSaved)
-		Xtest = libdrynxencoding.MatrixToFloat2D(matrixXTest)
+		libdrynxencoding.StandardiseWithTrain(matrixXTest, XtrainSaved)
 	} else if preprocessing == PREPROCESSING_NORMALIZE {
-		Xtest, err = libdrynxencoding.NormalizeWith(Xtest, XtrainSaved)
+		libdrynxencoding.NormalizeWith(matrixXTest, XtrainSaved)
 	}
-	if err != nil {
-		return 0, 0, 0, 0, 0, err
-	}
+	Xtest = libdrynxencoding.MatrixToFloat2D(matrixXTest)
 	// note: the test data does not need to be augmented with 1s
 
 	predictions := make([]int64, len(Xtest))

--- a/lib/encoding/logistic_regression_test.go
+++ b/lib/encoding/logistic_regression_test.go
@@ -348,7 +348,6 @@ func TestGradient(t *testing.T) {
 	y := []int64{1}
 	k := 1
 	N := len(X) //len(X[0]) * 10
-	N64 := int64(N)
 
 	lambda := 10.0
 	step := 0.0001
@@ -365,7 +364,7 @@ func TestGradient(t *testing.T) {
 			expected[i] += (lambda / float64(N)) * weights[i]
 		}
 	}
-	actual := libdrynxencoding.Gradient(weights, approxCoeffs, k, N64, lambda)
+	actual := libdrynxencoding.Gradient(weights, approxCoeffs, k, int64(N), lambda)
 	assert.Equal(t, expected[1:], actual[1:])
 
 	// libdrynxencoding.Gradient for k = 2
@@ -373,7 +372,7 @@ func TestGradient(t *testing.T) {
 	approxCoeffs = libdrynxencoding.ComputeAllApproxCoefficients(X[0], y[0], k)
 
 	expected = libdrynxencoding.GradientFor2(weights, approxCoeffs, k, N, lambda)
-	actual = libdrynxencoding.Gradient(weights, approxCoeffs, k, N64, lambda)
+	actual = libdrynxencoding.Gradient(weights, approxCoeffs, k, int64(N), lambda)
 	assert.Equal(t, expected[1:], actual[1:])
 
 	testX := make([][]float64, 1)
@@ -391,7 +390,6 @@ func TestCost(t *testing.T) {
 	y := []int64{1}
 	k := 1
 	N := len(X)
-	N64 := int64(N)
 
 	lambda := 1.0
 
@@ -414,7 +412,7 @@ func TestCost(t *testing.T) {
 		expectedCost += weights[i] * weights[i] * (lambda / 2 * float64(N))
 	}
 
-	actuaCost := libdrynxencoding.Cost(weights, aggregatedApproxCoeffs, N64, lambda)
+	actuaCost := libdrynxencoding.Cost(weights, aggregatedApproxCoeffs, int64(N), lambda)
 
 	assert.Equal(t, expectedCost, actuaCost)
 }
@@ -596,7 +594,6 @@ func TestEncodeDecodeLogisticRegression(t *testing.T) {
 	XStandardised := libdrynxencoding.MatrixToFloat2D(matrixXStandardised)
 
 	N := len(X)
-	N64 := int64(N)
 	d := int64(len(X[0]))
 
 	k := 2
@@ -620,12 +617,12 @@ func TestEncodeDecodeLogisticRegression(t *testing.T) {
 	// aggregate the approximation coefficients locally
 	aggregatedApproxCoefficients := libdrynxencoding.AggregateApproxCoefficients(approxCoefficients)
 
-	expected := libdrynxencoding.FindMinimumWeights(aggregatedApproxCoefficients, initialWeights, N64, lambda, step,
+	expected := libdrynxencoding.FindMinimumWeights(aggregatedApproxCoefficients, initialWeights, int64(N), lambda, step,
 		maxIterations)
 
 	initialWeights = []float64{0.1, 0.2, 0.3, 0.4, 0.5} // libdrynxencoding.FindMinimumWeights modifies the initial weights...
 
-	lrParameters := libdrynx.LogisticRegressionParameters{FilePath: "", NbrRecords: N64, NbrFeatures: d, Lambda: lambda, Step: step, MaxIterations: maxIterations,
+	lrParameters := libdrynx.LogisticRegressionParameters{FilePath: "", NbrRecords: int64(N), NbrFeatures: d, Lambda: lambda, Step: step, MaxIterations: maxIterations,
 		InitialWeights: initialWeights, K: 2, PrecisionApproxCoefficients: precision}
 
 	resultEncrypted, _, err := libdrynxencoding.EncodeLogisticRegression(X, y, lrParameters, pubKey)
@@ -665,7 +662,6 @@ func TestEncodeDecodeLogisticRegressionWithProofs(t *testing.T) {
 	XStandardised := libdrynxencoding.MatrixToFloat2D(matrixXStandardised)
 
 	N := len(X)
-	N64 := int64(N)
 	d := int64(len(X[0]))
 
 	k := 2
@@ -689,12 +685,12 @@ func TestEncodeDecodeLogisticRegressionWithProofs(t *testing.T) {
 	// aggregate the approximation coefficients locally
 	aggregatedApproxCoefficients := libdrynxencoding.AggregateApproxCoefficients(approxCoefficients)
 
-	expected := libdrynxencoding.FindMinimumWeights(aggregatedApproxCoefficients, initialWeights, N64, lambda, step,
+	expected := libdrynxencoding.FindMinimumWeights(aggregatedApproxCoefficients, initialWeights, int64(N), lambda, step,
 		maxIterations)
 
 	initialWeights = []float64{0.1, 0.2, 0.3, 0.4, 0.5} // libdrynxencoding.FindMinimumWeights modifies the initial weights...
 
-	lrParameters := libdrynx.LogisticRegressionParameters{FilePath: "", NbrRecords: N64, NbrFeatures: d, Lambda: lambda, Step: step, MaxIterations: maxIterations,
+	lrParameters := libdrynx.LogisticRegressionParameters{FilePath: "", NbrRecords: int64(N), NbrFeatures: d, Lambda: lambda, Step: step, MaxIterations: maxIterations,
 		InitialWeights: initialWeights, K: 2, PrecisionApproxCoefficients: precision}
 
 	//signatures needed to check the proof; create signatures for 2 servers and all DPs outputs

--- a/lib/encoding/logistic_regression_test.go
+++ b/lib/encoding/logistic_regression_test.go
@@ -768,7 +768,7 @@ func TestStandardise(t *testing.T) {
 	epsilon := 1e-12
 	for i := 0; i < len(XStandardised); i++ {
 		for j := 0; j < len(XStandardised[i]); j++ {
-			assert.Equal(t, true, math.Abs(XStandardised[i][j]-XScaledStandardised[i][j]) < epsilon)
+			assert.InEpsilon(t, XStandardised[i][j], XScaledStandardised[i][j], epsilon)
 		}
 	}
 

--- a/lib/encoding/logistic_regression_test.go
+++ b/lib/encoding/logistic_regression_test.go
@@ -590,9 +590,9 @@ func TestEncodeDecodeLogisticRegression(t *testing.T) {
 	require.NoError(t, err)
 	y := libdrynxencoding.Float64ToInt641DArray(yFloat)
 
-	XStandardised, err := libdrynxencoding.Standardise(X)
-	require.NoError(t, err)
-	XStandardised = libdrynxencoding.Augment(XStandardised)
+	matrixXStandardised := libdrynxencoding.Float2DToMatrix(X)
+	libdrynxencoding.Standardise(matrixXStandardised)
+	XStandardised := libdrynxencoding.Augment(libdrynxencoding.MatrixToFloat2D(matrixXStandardised))
 
 	N := len(X)
 	N64 := int64(N)
@@ -658,9 +658,9 @@ func TestEncodeDecodeLogisticRegressionWithProofs(t *testing.T) {
 	require.NoError(t, err)
 	y := libdrynxencoding.Float64ToInt641DArray(yFloat)
 
-	XStandardised, err := libdrynxencoding.Standardise(X)
-	require.NoError(t, err)
-	XStandardised = libdrynxencoding.Augment(XStandardised)
+	matrixXStandardised := libdrynxencoding.Float2DToMatrix(X)
+	libdrynxencoding.Standardise(matrixXStandardised)
+	XStandardised := libdrynxencoding.Augment(libdrynxencoding.MatrixToFloat2D(matrixXStandardised))
 
 	N := len(X)
 	N64 := int64(N)
@@ -757,10 +757,13 @@ func TestStandardise(t *testing.T) {
 		}
 	}
 
-	XStandardised, err := libdrynxencoding.Standardise(X)
-	require.NoError(t, err)
-	XScaledStandardised, err := libdrynxencoding.Standardise(XScaled)
-	require.NoError(t, err)
+	matrixXStandardised := libdrynxencoding.Float2DToMatrix(X)
+	libdrynxencoding.Standardise(matrixXStandardised)
+	XStandardised := libdrynxencoding.Augment(libdrynxencoding.MatrixToFloat2D(matrixXStandardised))
+
+	matrixXScaledStandardised := libdrynxencoding.Float2DToMatrix(X)
+	libdrynxencoding.Standardise(matrixXScaledStandardised)
+	XScaledStandardised := libdrynxencoding.Augment(libdrynxencoding.MatrixToFloat2D(matrixXStandardised))
 
 	epsilon := 1e-12
 	for i := 0; i < len(XStandardised); i++ {

--- a/lib/encoding/logistic_regression_test.go
+++ b/lib/encoding/logistic_regression_test.go
@@ -592,7 +592,8 @@ func TestEncodeDecodeLogisticRegression(t *testing.T) {
 
 	matrixXStandardised := libdrynxencoding.Float2DToMatrix(X)
 	libdrynxencoding.Standardise(matrixXStandardised)
-	XStandardised := libdrynxencoding.Augment(libdrynxencoding.MatrixToFloat2D(matrixXStandardised))
+	matrixXStandardised = libdrynxencoding.Augment(matrixXStandardised)
+	XStandardised := libdrynxencoding.MatrixToFloat2D(matrixXStandardised)
 
 	N := len(X)
 	N64 := int64(N)
@@ -660,7 +661,8 @@ func TestEncodeDecodeLogisticRegressionWithProofs(t *testing.T) {
 
 	matrixXStandardised := libdrynxencoding.Float2DToMatrix(X)
 	libdrynxencoding.Standardise(matrixXStandardised)
-	XStandardised := libdrynxencoding.Augment(libdrynxencoding.MatrixToFloat2D(matrixXStandardised))
+	matrixXStandardised = libdrynxencoding.Augment(matrixXStandardised)
+	XStandardised := libdrynxencoding.MatrixToFloat2D(matrixXStandardised)
 
 	N := len(X)
 	N64 := int64(N)
@@ -759,11 +761,13 @@ func TestStandardise(t *testing.T) {
 
 	matrixXStandardised := libdrynxencoding.Float2DToMatrix(X)
 	libdrynxencoding.Standardise(matrixXStandardised)
-	XStandardised := libdrynxencoding.Augment(libdrynxencoding.MatrixToFloat2D(matrixXStandardised))
+	matrixXStandardised = libdrynxencoding.Augment(matrixXStandardised)
+	XStandardised := libdrynxencoding.MatrixToFloat2D(matrixXStandardised)
 
 	matrixXScaledStandardised := libdrynxencoding.Float2DToMatrix(X)
 	libdrynxencoding.Standardise(matrixXScaledStandardised)
-	XScaledStandardised := libdrynxencoding.Augment(libdrynxencoding.MatrixToFloat2D(matrixXStandardised))
+	matrixXScaledStandardised = libdrynxencoding.Augment(matrixXScaledStandardised)
+	XScaledStandardised := libdrynxencoding.MatrixToFloat2D(matrixXScaledStandardised)
 
 	epsilon := 1e-12
 	for i := 0; i < len(XStandardised); i++ {

--- a/services/service_test.go
+++ b/services/service_test.go
@@ -406,8 +406,7 @@ func TestServiceDrynxLogisticRegressionForSPECTF(t *testing.T) {
 	var means = make([]float64, 0)
 	var standardDeviations = make([]float64, 0)
 	if standardisationMode == 0 || standardisationMode == 1 {
-		means, err = libdrynxencoding.ComputeMeans(XTrain)
-		require.NoError(t, err)
+		means = libdrynxencoding.ComputeMeans(libdrynxencoding.Float2DToMatrix(XTrain))
 		standardDeviations, err = libdrynxencoding.ComputeStandardDeviations(XTrain)
 		require.NoError(t, err)
 	} else {
@@ -866,8 +865,7 @@ func TestServiceDrynxLogisticRegression(t *testing.T) {
 		var means = make([]float64, 0)
 		var standardDeviations = make([]float64, 0)
 		if standardisationMode == 0 || standardisationMode == 1 {
-			means, err = libdrynxencoding.ComputeMeans(XTrain)
-			require.NoError(t, err)
+			means = libdrynxencoding.ComputeMeans(libdrynxencoding.Float2DToMatrix(XTrain))
 			standardDeviations, err = libdrynxencoding.ComputeStandardDeviations(XTrain)
 			require.NoError(t, err)
 		} else {
@@ -1153,8 +1151,7 @@ func TestServiceDrynxLogisticRegressionV2(t *testing.T) {
 	var means = make([]float64, 0)
 	var standardDeviations = make([]float64, 0)
 	if standardisationMode == 0 || standardisationMode == 1 {
-		means, err = libdrynxencoding.ComputeMeans(XTrain)
-		require.NoError(t, err)
+		means = libdrynxencoding.ComputeMeans(libdrynxencoding.Float2DToMatrix(XTrain))
 		standardDeviations, err = libdrynxencoding.ComputeStandardDeviations(XTrain)
 		require.NoError(t, err)
 	} else {
@@ -1542,8 +1539,7 @@ func TestServiceDrynxLogisticRegressionBC(t *testing.T) {
 	var means = make([]float64, 0)
 	var standardDeviations = make([]float64, 0)
 	if standardisationMode == 0 || standardisationMode == 1 {
-		means, err = libdrynxencoding.ComputeMeans(XTrain)
-		require.NoError(t, err)
+		means = libdrynxencoding.ComputeMeans(libdrynxencoding.Float2DToMatrix(XTrain))
 		standardDeviations, err = libdrynxencoding.ComputeStandardDeviations(XTrain)
 		require.NoError(t, err)
 	} else {
@@ -1950,8 +1946,7 @@ func TestServiceDrynxLogisticRegressionGSE(t *testing.T) {
 	var means = make([]float64, 0)
 	var standardDeviations = make([]float64, 0)
 	if standardisationMode == 0 || standardisationMode == 1 {
-		means, err = libdrynxencoding.ComputeMeans(XTrain)
-		require.NoError(t, err)
+		means = libdrynxencoding.ComputeMeans(libdrynxencoding.Float2DToMatrix(XTrain))
 		standardDeviations, err = libdrynxencoding.ComputeStandardDeviations(XTrain)
 		require.NoError(t, err)
 	} else {

--- a/services/service_test.go
+++ b/services/service_test.go
@@ -996,20 +996,18 @@ func performanceEvaluation(weights []float64, XTest [][]float64, yTest []int64, 
 	float64, float64, float64, float64, error) {
 	fmt.Println("weights:", weights)
 
+	X := libdrynxencoding.Float2DToMatrix(XTest)
 	if means != nil && standardDeviations != nil &&
 		len(means) > 0 && len(standardDeviations) > 0 {
 		// using global means and standard deviations, if given
 		log.Lvl1("Standardising the testing set with global means and standard deviations...")
-		XTest = libdrynxencoding.StandardiseWith(XTest, means, standardDeviations)
+		libdrynxencoding.StandardiseWith(X, means, standardDeviations)
 	} else {
 		// using local means and standard deviations, if not given
 		log.Lvl1("Standardising the testing set with local means and standard deviations...")
-		var err error
-		XTest, err = libdrynxencoding.Standardise(XTest)
-		if err != nil {
-			return 0, 0, 0, 0, 0, err
-		}
+		libdrynxencoding.Standardise(X)
 	}
+	XTest = libdrynxencoding.MatrixToFloat2D(X)
 
 	predictions := make([]int64, len(XTest))
 	predictionsFloat := make([]float64, len(XTest))

--- a/services/service_test.go
+++ b/services/service_test.go
@@ -395,10 +395,13 @@ func TestServiceDrynxLogisticRegressionForSPECTF(t *testing.T) {
 	filePathTraining := "../data/SPECTF_heart_dataset_training.txt"
 	filePathTesting := "../data/SPECTF_heart_dataset_testing.txt"
 
-	XTrain, _, err := libdrynxencoding.LoadData("SPECTF", filePathTraining)
+	trainMatrix, _, err := libdrynxencoding.LoadData("SPECTF", filePathTraining)
 	require.NoError(t, err)
-	XTest, yTest, err := libdrynxencoding.LoadData("SPECTF", filePathTesting)
+	testMatrix, testVector, err := libdrynxencoding.LoadData("SPECTF", filePathTesting)
 	require.NoError(t, err)
+
+	XTrain := libdrynxencoding.MatrixToFloat2D(trainMatrix)
+	XTest, yTest := libdrynxencoding.MatrixToFloat2D(testMatrix), libdrynxencoding.VectorToInt(testVector)
 
 	var means = make([]float64, 0)
 	var standardDeviations = make([]float64, 0)
@@ -827,8 +830,10 @@ func TestServiceDrynxLogisticRegression(t *testing.T) {
 	fmt.Println(filepath)
 
 	// load the dataset
-	X, y, err := libdrynxencoding.LoadData(dataset, filepath)
+	matrix, vector, err := libdrynxencoding.LoadData(dataset, filepath)
 	require.NoError(t, err)
+
+	X, y := libdrynxencoding.MatrixToFloat2D(matrix), libdrynxencoding.VectorToInt(vector)
 
 	for i := 0; i < numberTrials; i++ {
 		log.Lvl1("Evaluating prediction on dataset for trial:", i)
@@ -1137,10 +1142,13 @@ func TestServiceDrynxLogisticRegressionV2(t *testing.T) {
 	filePathTraining := "../data/" + dataset + "_dataset_training.txt"
 	filePathTesting := "../data/" + dataset + "_dataset_testing.txt"
 
-	XTrain, _, err := libdrynxencoding.LoadData(dataset, filePathTraining)
+	trainMatrix, _, err := libdrynxencoding.LoadData(dataset, filePathTraining)
 	require.NoError(t, err)
-	XTest, yTest, err := libdrynxencoding.LoadData(dataset, filePathTesting)
+	testMatrix, testVector, err := libdrynxencoding.LoadData(dataset, filePathTesting)
 	require.NoError(t, err)
+
+	XTrain := libdrynxencoding.MatrixToFloat2D(trainMatrix)
+	XTest, yTest := libdrynxencoding.MatrixToFloat2D(testMatrix), libdrynxencoding.VectorToInt(testVector)
 
 	var means = make([]float64, 0)
 	var standardDeviations = make([]float64, 0)
@@ -1523,10 +1531,13 @@ func TestServiceDrynxLogisticRegressionBC(t *testing.T) {
 	filePathTraining := "../tmpdata/" + dataset + "_dataset_training.txt"
 	filePathTesting := "../tmpdata/" + dataset + "_dataset_testing.txt"
 
-	XTrain, _, err := libdrynxencoding.LoadData(dataset, filePathTraining)
+	trainMatrix, _, err := libdrynxencoding.LoadData(dataset, filePathTraining)
 	require.NoError(t, err)
-	XTest, yTest, err := libdrynxencoding.LoadData(dataset, filePathTesting)
+	testMatrix, testVector, err := libdrynxencoding.LoadData(dataset, filePathTesting)
 	require.NoError(t, err)
+
+	XTrain := libdrynxencoding.MatrixToFloat2D(trainMatrix)
+	XTest, yTest := libdrynxencoding.MatrixToFloat2D(testMatrix), libdrynxencoding.VectorToInt(testVector)
 
 	var means = make([]float64, 0)
 	var standardDeviations = make([]float64, 0)
@@ -1928,10 +1939,13 @@ func TestServiceDrynxLogisticRegressionGSE(t *testing.T) {
 	filePathTraining := "../tmpdata/" + dataset + "_dataset_training.txt"
 	filePathTesting := "../tmpdata/" + dataset + "_dataset_testing.txt"
 
-	XTrain, _, err := libdrynxencoding.LoadData(dataset, filePathTraining)
+	trainMatrix, _, err := libdrynxencoding.LoadData(dataset, filePathTraining)
 	require.NoError(t, err)
-	XTest, yTest, err := libdrynxencoding.LoadData(dataset, filePathTesting)
+	testMatrix, testVector, err := libdrynxencoding.LoadData(dataset, filePathTesting)
 	require.NoError(t, err)
+
+	XTrain := libdrynxencoding.MatrixToFloat2D(trainMatrix)
+	XTest, yTest := libdrynxencoding.MatrixToFloat2D(testMatrix), libdrynxencoding.VectorToInt(testVector)
 
 	var means = make([]float64, 0)
 	var standardDeviations = make([]float64, 0)

--- a/services/service_test.go
+++ b/services/service_test.go
@@ -403,15 +403,11 @@ func TestServiceDrynxLogisticRegressionForSPECTF(t *testing.T) {
 	XTrain := libdrynxencoding.MatrixToFloat2D(trainMatrix)
 	XTest, yTest := libdrynxencoding.MatrixToFloat2D(testMatrix), libdrynxencoding.VectorToInt(testVector)
 
-	var means = make([]float64, 0)
-	var standardDeviations = make([]float64, 0)
+	var means []float64
+	var standardDeviations []float64
 	if standardisationMode == 0 || standardisationMode == 1 {
 		means = libdrynxencoding.ComputeMeans(libdrynxencoding.Float2DToMatrix(XTrain))
-		standardDeviations, err = libdrynxencoding.ComputeStandardDeviations(XTrain)
-		require.NoError(t, err)
-	} else {
-		means = nil
-		standardDeviations = nil
+		standardDeviations = libdrynxencoding.ComputeStandardDeviations(libdrynxencoding.Float2DToMatrix(XTrain))
 	}
 
 	lrParameters.DatasetName = "SPECTF"
@@ -862,15 +858,11 @@ func TestServiceDrynxLogisticRegression(t *testing.T) {
 			_, err = fileTesting.WriteString(fmt.Sprintln(testingSet[i][len(testingSet[i])-1]))
 		}
 
-		var means = make([]float64, 0)
-		var standardDeviations = make([]float64, 0)
+		var means []float64
+		var standardDeviations []float64
 		if standardisationMode == 0 || standardisationMode == 1 {
 			means = libdrynxencoding.ComputeMeans(libdrynxencoding.Float2DToMatrix(XTrain))
-			standardDeviations, err = libdrynxencoding.ComputeStandardDeviations(XTrain)
-			require.NoError(t, err)
-		} else {
-			means = nil
-			standardDeviations = nil
+			standardDeviations = libdrynxencoding.ComputeStandardDeviations(libdrynxencoding.Float2DToMatrix(XTrain))
 		}
 
 		lrParameters.FilePath = filePathTraining
@@ -1148,15 +1140,11 @@ func TestServiceDrynxLogisticRegressionV2(t *testing.T) {
 	XTrain := libdrynxencoding.MatrixToFloat2D(trainMatrix)
 	XTest, yTest := libdrynxencoding.MatrixToFloat2D(testMatrix), libdrynxencoding.VectorToInt(testVector)
 
-	var means = make([]float64, 0)
-	var standardDeviations = make([]float64, 0)
+	var means []float64
+	var standardDeviations []float64
 	if standardisationMode == 0 || standardisationMode == 1 {
 		means = libdrynxencoding.ComputeMeans(libdrynxencoding.Float2DToMatrix(XTrain))
-		standardDeviations, err = libdrynxencoding.ComputeStandardDeviations(XTrain)
-		require.NoError(t, err)
-	} else {
-		means = nil
-		standardDeviations = nil
+		standardDeviations = libdrynxencoding.ComputeStandardDeviations(libdrynxencoding.Float2DToMatrix(XTrain))
 	}
 
 	lrParameters.FilePath = filePathTraining
@@ -1536,15 +1524,11 @@ func TestServiceDrynxLogisticRegressionBC(t *testing.T) {
 	XTrain := libdrynxencoding.MatrixToFloat2D(trainMatrix)
 	XTest, yTest := libdrynxencoding.MatrixToFloat2D(testMatrix), libdrynxencoding.VectorToInt(testVector)
 
-	var means = make([]float64, 0)
-	var standardDeviations = make([]float64, 0)
+	var means []float64
+	var standardDeviations []float64
 	if standardisationMode == 0 || standardisationMode == 1 {
 		means = libdrynxencoding.ComputeMeans(libdrynxencoding.Float2DToMatrix(XTrain))
-		standardDeviations, err = libdrynxencoding.ComputeStandardDeviations(XTrain)
-		require.NoError(t, err)
-	} else {
-		means = nil
-		standardDeviations = nil
+		standardDeviations = libdrynxencoding.ComputeStandardDeviations(libdrynxencoding.Float2DToMatrix(XTrain))
 	}
 
 	lrParameters.FilePath = filePathTraining
@@ -1943,15 +1927,11 @@ func TestServiceDrynxLogisticRegressionGSE(t *testing.T) {
 	XTrain := libdrynxencoding.MatrixToFloat2D(trainMatrix)
 	XTest, yTest := libdrynxencoding.MatrixToFloat2D(testMatrix), libdrynxencoding.VectorToInt(testVector)
 
-	var means = make([]float64, 0)
-	var standardDeviations = make([]float64, 0)
+	var means []float64
+	var standardDeviations []float64
 	if standardisationMode == 0 || standardisationMode == 1 {
 		means = libdrynxencoding.ComputeMeans(libdrynxencoding.Float2DToMatrix(XTrain))
-		standardDeviations, err = libdrynxencoding.ComputeStandardDeviations(XTrain)
-		require.NoError(t, err)
-	} else {
-		means = nil
-		standardDeviations = nil
+		standardDeviations = libdrynxencoding.ComputeStandardDeviations(libdrynxencoding.Float2DToMatrix(XTrain))
 	}
 
 	lrParameters.FilePath = filePathTraining


### PR DESCRIPTION
To avoid much memory footprint, instead of rebuilding a new matrix when removing a column or doing some transformation on it, use `gonum/mat.Matrix` which modify the data in place and tries to avoid copying as much as possible.